### PR TITLE
Adding Aligning Model for welsh

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -63,6 +63,7 @@ DEFAULT_ALIGN_MODELS_HF = {
     "sk": "comodoro/wav2vec2-xls-r-300m-sk-cv8",
     "sl": "anton-l/wav2vec2-large-xlsr-53-slovenian",
     "hr": "classla/wav2vec2-xls-r-parlaspeech-hr",
+    "cy": "Srulikbdd/Wav2Vec2-large-xlsr-welsh",
 }
 
 


### PR DESCRIPTION
Adding default model for Welsh (cy). 

https://huggingface.co/Srulikbdd/Wav2Vec2-large-xlsr-welsh

This is useful when cy is detected in multilanguage recordings. 